### PR TITLE
Fix crash when fps are double values

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ module.exports = async (opts) => {
     throw new Error('Must pass either "animationData" or "path"')
   }
 
-  const fps = lottieData.fr
+  const fps = ~~lottieData.fr
   const { w = 640, h = 480 } = lottieData
   const aR = w / h
 


### PR DESCRIPTION
Tried with a simple Lottie file and received an error about the fps being an invalid value. I researched and found out that the value was given with a lot of decimals and that was making trouble. Just rounded the value with no decimals and the error was fixed. I made a few tests and no content is loss.