### PR TITLE
add ability to snapshot specific frames

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,7 +347,7 @@ ${inject.body || ''}
       : tempOutput
 
     // default to specified frame or loop (should only be useful for single frame)
-    var cframe = captureFrame || frame
+    var cframe = !isMultiFrame &&  (captureFrame || frame)
 
     // eslint-disable-next-line no-undef
     await page.evaluate((cframe) => animation.goToAndStop(cframe, true), cframe)

--- a/index.js
+++ b/index.js
@@ -347,7 +347,7 @@ ${inject.body || ''}
       : tempOutput
 
     // default to specified frame or loop (should only be useful for single frame)
-    var cframe = !isMultiFrame &&  (captureFrame || frame)
+    var cframe = !isMultiFrame && (captureFrame || frame)
 
     // eslint-disable-next-line no-undef
     await page.evaluate((cframe) => animation.goToAndStop(cframe, true), cframe)

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ const injectLottie = `
  * @param {string} [opts.path] - Relative path to the JSON file containing animation data
  * @param {number} [opts.width] - Optional output width
  * @param {number} [opts.height] - Optional output height
+ * @param {number} [opts.captureFrame] - Optional specific frame to capture
  * @param {object} [opts.jpegQuality=90] - JPEG quality for frames (does nothing if using png)
  * @param {object} [opts.quiet=false] - Set to true to disable console output
  * @param {number} [opts.deviceScaleFactor=1] - Window device scale factor
@@ -83,7 +84,8 @@ module.exports = async (opts) => {
 
   let {
     width = undefined,
-    height = undefined
+    height = undefined,
+    captureFrame = undefined
   } = opts
 
   ow(output, ow.string.nonEmpty, 'output')
@@ -344,8 +346,11 @@ ${inject.body || ''}
       ? sprintf(tempOutput, frame)
       : tempOutput
 
+    // default to specified frame or loop (should only be useful for single frame)
+    var cframe = captureFrame || frame
+
     // eslint-disable-next-line no-undef
-    await page.evaluate((frame) => animation.goToAndStop(frame, true), frame)
+    await page.evaluate((cframe) => animation.goToAndStop(cframe, true), cframe)
     const screenshot = await rootHandle.screenshot({
       path: isMp4 ? undefined : frameOutputPath,
       ...screenshotOpts

--- a/index.test.js
+++ b/index.test.js
@@ -45,6 +45,24 @@ test('bodymovin.json => single frame jpg scale=640:-1', async (t) => {
   await fs.remove(output)
 })
 
+test('bodymovin.json => single frame[10] jpg scale=640:-1', async (t) => {
+  const output = tempy.file({ extension: 'jpg' })
+
+  await renderLottie({
+    path: bodymovin,
+    quiet: true,
+    width: 640,
+    captureFrame: 10,
+    output
+  })
+
+  const image = imageSize(output)
+  t.is(image.width, 640)
+  t.is(image.height, 96)
+
+  await fs.remove(output)
+})
+
 test('bodymovin.json => png frames scale=-1:100', async (t) => {
   const temp = tempy.directory()
   const output = path.join(temp, 'frame-%d.png')

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,14 @@ await renderLottie({
   path: 'fixtures/bodymovin.json',
   output: 'preview.jpg'
 })
+
+
+// Render the tenth frame of the animation as a JPEG image
+await renderLottie({
+  path: 'fixtures/bodymovin.json',
+  output: 'preview.jpg',
+  captureFrame: 10
+})
 ```
 
 #### Output Size
@@ -95,6 +103,7 @@ Type: `function (opts): Promise`
     -   `opts.path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Relative path to the JSON file containing animation data
     -   `opts.width` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Optional output width
     -   `opts.height` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Optional output height
+    -   `opts.captureFrame` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Optional frame number to capture
     -   `opts.jpegQuality` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** JPEG quality for frames (does nothing if using png) (optional, default `90`)
     -   `opts.quiet` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Set to true to disable console output (optional, default `false`)
     -   `opts.deviceScaleFactor` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** Window device scale factor (optional, default `1`)

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,6 @@ await renderLottie({
   output: 'preview.jpg'
 })
 
-
 // Render the tenth frame of the animation as a JPEG image
 await renderLottie({
   path: 'fixtures/bodymovin.json',


### PR DESCRIPTION
when exporting single images, specifying the optional `captureFrame` will export the specific frame instead of the first one