### PR TITLE
Remove frame shift in animation rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,9 +355,9 @@ ${inject.body || ''}
     })
   }
 
-  for (let frame = 1; frame <= numFrames; ++frame) {
+  for (let frame = 0; frame < numFrames; ++frame) {
     const frameOutputPath = isMultiFrame
-      ? sprintf(tempOutput, frame)
+      ? sprintf(tempOutput, frame + 1)
       : tempOutput
 
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
It is an addition to #13: lottie animation rendering starts from the 2nd frame and stops on non-existing frame located after the last. Because of this, a blank frame appears at the end of the GIF animation.

I kept output indexes unmodified mentioned in [this](https://github.com/transitive-bullshit/puppeteer-lottie/pull/13#issuecomment-570796104) comment.