### PR TITLE
Make 60fps lottie animations not so slow after converted

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,7 +407,7 @@ ${inject.body || ''}
 
     const params = [
       '-o', escapePath(output),
-      '--fps', gifskiOptions.fps || fps,
+      '--fps', Math.min(gifskiOptions.fps || fps, 50), // most of viewers do not support gifs with FPS > 50
       gifskiOptions.fast && '--fast',
       '--quality', gifskiOptions.quality,
       '--quiet',


### PR DESCRIPTION
The most of gif viewers do not support gifs with fps greater than 50.
Explanation [here](https://video.stackexchange.com/a/30160):
>There is no such thing as 60fps GIFs.
>
>GIF files store delay time between frames in whole hundredths of second, so it's impossible to make a GIF with exactly 60fps, because value 1 would give you 100fps and 2 would already have half of that - 50fps. Besides that, many programs (including Google Chrome) ignore value 1 and defaults to much slower animation speed when viewing such files, so 100fps GIFs, while technically possible according to file format, are not commonly used and probably a bad idea, so value 2 (50fps) is the most you can get.

Discussion if you're interested: https://github.com/ed-asriyan/tgs-to-gif/issues/13