### PR TITLE
Don't write frames to output path for apng files

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,7 +365,7 @@ ${inject.body || ''}
     // eslint-disable-next-line no-undef
     await page.evaluate((frame) => animation.goToAndStop(frame, true), frame)
     const screenshot = await rootHandle.screenshot({
-      path: isMp4 ? undefined : frameOutputPath,
+      path: (isApng || isMp4) ? undefined : frameOutputPath,
       ...screenshotOpts
     })
     


### PR DESCRIPTION
Only let ffmpeg output data to output path to avoid corrupting apng output file