### PR TITLE
Wrap output into quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -412,7 +412,7 @@ ${inject.body || ''}
     const escapePath = arg => arg.replace(/(\s+)/g, '\\$1')
 
     const params = [
-      '-o', escapePath(output),
+      '-o', `"${escapePath(output)}"`,
       '--fps', Math.min(gifskiOptions.fps || fps, 50), // most of viewers do not support gifs with FPS > 50
       gifskiOptions.fast && '--fast',
       '--quality', gifskiOptions.quality,


### PR DESCRIPTION
There is a bug. Gifski call fails if output path contains '(' character.

More details here: https://github.com/ed-asriyan/tgs-to-gif/issues/48

This PR fixes this issue.
